### PR TITLE
Remove callbackURL option from Github Passport Strategy

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -38,8 +38,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 passport.use(new Strategy({
     clientID: GITHUB_CLIENT_ID,
-    clientSecret: GITHUB_CLIENT_SECRET,
-    callbackURL: 'http://' + SERVER + ':' + PORT + '/auth/github/callback'
+    clientSecret: GITHUB_CLIENT_SECRET
   },
   function(accessToken, refreshToken, profile, cb) {
     // User.findOrCreate({ githubId: profile.id }, function (err, user) {


### PR DESCRIPTION
It seems that the callbackURL option that was being passed into the Gitub Passport Strategy isn't necessary and it was causing problems on the deploy server so I removed it.
