### PR TITLE
Remove annotation drag and drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
     "request": "^2.72.0"
   },
   "devDependencies": {
-    "angular-multiple-drag": "0.0.1",
-    "angular-multiple-selection": "0.0.3",
     "chai": "^3.5.0",
     "mocha": "^2.5.3",
     "supertest": "^1.2.0"

--- a/public/app/snippet.js
+++ b/public/app/snippet.js
@@ -1,14 +1,4 @@
-// A function which compiles an element into angular form
-function compile(element){
-  var el = angular.element(element);    
-  $scope = el.scope();
-  $injector = el.injector();
-  $injector.invoke(function($compile){
-    $compile(el)($scope);
-  });
-}
-
-angular.module('app.snippet', ['multipleDrag'])
+angular.module('app.snippet', [])
 .controller('SnippetController', function($scope, $http) {
 
   var ranges = [];
@@ -99,15 +89,6 @@ angular.module('app.snippet', ['multipleDrag'])
       note.setAttribute("contenteditable", "true");
       note.setAttribute("spellcheck", "false");
       note.classList.add('highlighted-' + colorCount);
-      // Make annotation draggable
-      // Reference: https://www.npmjs.com/package/angular-multiple-drag
-      // Example: http://jsfiddle.net/r2vb1ahy/
-      // Example: http://maxazan.github.io/angular-multiple-drag/ => we can view the page source as well
-      note.setAttribute("multiple-selection-item");
-      note.setAttribute("multiple-drag-item");
-      note.setAttribute("ng-class", "{'selecting': isSelecting ,'selected': isSelected,'dragging': isDragging}");
-      // Since we include angular classes and attributes we need to compile the element
-      compile(note);
       elem.appendChild(note);
       note.focus();
 

--- a/public/index.html
+++ b/public/index.html
@@ -27,8 +27,6 @@
     <script src="node_modules/ace-builds/src-noconflict/ace.js" type="text/javascript" charset="utf-8"></script>
     <script src="node_modules/angular/angular.min.js"></script>
     <script src="node_modules/angular-route/angular-route.min.js"></script>
-    <script src="node_modules/angular-multiple-selection/multiple-selection.min.js"></script>
-    <script src="node_modules/angular-multiple-drag/multiple-drag.min.js"></script>
     <script src="app/main.js"></script>
     <script src="app/snippet.js"></script>
     <script src="app/view.js"></script>


### PR DESCRIPTION
The previous merge broke functionality. Removing this until the drag and drop
functionality is tested and working.
