### PR TITLE
Remove teaser class from Snippets pages

### DIFF
--- a/public/app/snippets.html
+++ b/public/app/snippets.html
@@ -1,4 +1,4 @@
-<div class="teaser" ng-repeat="snippet in snippets" on-finish-render="ngRepeatFinished">
+<div class="snippets" ng-repeat="snippet in snippets" on-finish-render="ngRepeatFinished">
   <!-- snippet start -->
   <div class="form-wrap">
     <h2>{{ snippet.title }}</h2>

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -151,10 +151,18 @@ label {
   display: inline-block;
 }
 
+/* snippets view page */
+
 .missing-snippet {
   width: 100%;
   text-align: center;
   margin-bottom: 10px;
+}
+
+/* all snippets page */
+
+.snippets {
+  /* reserving class name */
 }
 
 


### PR DESCRIPTION
Teaser class was for the Main view. I replaced the `teaser` class with `snippets` class to reserve it for styling.
