### PR TITLE
Update $scope.ranges when annotations are reordered or changed

### DIFF
--- a/public/app/snippet.html
+++ b/public/app/snippet.html
@@ -60,6 +60,21 @@
       }
     });
 
-    $( "#annotations" ).sortable();
+    $( "#annotations" ).sortable({
+      start: function(event, div) {
+        var start_pos = div.item.index();
+        div.item.data('start_pos', start_pos);
+        console.log('starting position ===========>', start_pos);
+      },
+
+      change: function(event, div) {
+        var start_pos = div.item.data('start_pos');
+        var end_pos = div.placeholder.index();
+        if ( start_pos < end_pos ) {
+          end_pos -= 1;
+        }
+        console.log('ending position =============>', end_pos);
+      }
+    });
   });
 </script>

--- a/public/app/snippet.html
+++ b/public/app/snippet.html
@@ -31,9 +31,8 @@
 }
       </div><!-- remove space between inline-blocks
    --><div id="annotations">
-        <div ng-repeat="annotation in ranges" id="annotation-{{ annotation.id }}">
-          {{ note.message }}
-          <div class="note highlighted-{{ annotation.color }}" spellcheck="false" contenteditable="true">
+        <div ng-repeat="annotation in ranges track by $index" id="annotation-{{ annotation.id }}">
+          <div class="note highlighted-{{ annotation.color }}" spellcheck="false" contenteditable="true" ng-model="annotation.text"> {{annotation.text}}
           </div>
           <button type="button" class="trash" ng-click="removeAnnotation()">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
@@ -48,33 +47,6 @@
     <div class="btn-wrap">
       <button class="btn" type="submit">Save snippet</button>
     </div>
+
   </form>
 </div>
-
-<script>
-  $(function() {
-
-    $(document).on('click', '.note', function(e){
-      if (! $(this).is(":focus") ) {
-        this.focus();
-      }
-    });
-
-    $( "#annotations" ).sortable({
-      start: function(event, div) {
-        var start_pos = div.item.index();
-        div.item.data('start_pos', start_pos);
-        console.log('starting position ===========>', start_pos);
-      },
-
-      change: function(event, div) {
-        var start_pos = div.item.data('start_pos');
-        var end_pos = div.placeholder.index();
-        if ( start_pos < end_pos ) {
-          end_pos -= 1;
-        }
-        console.log('ending position =============>', end_pos);
-      }
-    });
-  });
-</script>

--- a/public/app/snippet.js
+++ b/public/app/snippet.js
@@ -113,7 +113,7 @@ angular.module('app.snippet', [])
       highlights: $scope.ranges,
       tags: tags
     };
-
+    console.log('Data of snippet that need to be saved into database =======>', snippet);
     $http({
       method: 'POST',
       url: '/snippets',

--- a/public/app/snippet.js
+++ b/public/app/snippet.js
@@ -90,6 +90,7 @@ angular.module('app.snippet', [])
     range.id = $scope.rangeId;
     range.color = $scope.colorCount;
     range.marker = marker;
+    range.text = '';
     $scope.ranges.push(range);
 
     // TODO: focus cursor to new annotation
@@ -97,9 +98,9 @@ angular.module('app.snippet', [])
   };
 
   $scope.snippetsCreate = function() {
-    $scope.ranges.forEach(function(range) {
-      range.text = document.getElementById('annotation-' + range.id).childNodes[1].innerText;
-    });
+    // $scope.ranges.forEach(function(range) {
+    //   range.text = document.getElementById('annotation-' + range.id).childNodes[1].innerText;
+    // });
 
     var tags = [];
     if ($scope.tags1) { tags.push($scope.tags1); }
@@ -146,9 +147,6 @@ angular.module('app.snippet', [])
     target.style.webkitTransform = target.style.transform =
         'translate(' + 0 + 'px,' + y + 'px)';
 
-    // $( "#annotations, #editor" ).animate({
-    //   height: event.rect.height
-    // }, 0);
     $( "#annotations, #editor" ).height(event.rect.height)
     editor.resize();
 
@@ -156,6 +154,65 @@ angular.module('app.snippet', [])
     target.setAttribute('data-y', y);
   });
 
+  $(document).on('click', '.note', function(e){
+      if (! $(this).is(":focus") ) {
+        this.focus();
+      }
+  });
 
+  var start_pos;
+  var end_pos;
+  $( "#annotations" ).sortable({
+    start: function(event, div) {
+      start_pos = div.item.index();
+      console.log('starting position ===========>', start_pos);
+    },
 
+    change: function(event, div) {
+      end_pos = div.placeholder.index();
+      if ( start_pos < end_pos ) {
+        end_pos -= 1;
+      }
+    },
+
+    stop: function(event) {
+      console.log('ending position =============>', end_pos);
+      // reorder $scope.ranges based on the order of annotations
+      var draggedAnnotation = $scope.ranges[start_pos];
+      if ( start_pos > end_pos ) {
+        for ( var i = start_pos; i > end_pos; i-- ) {
+          $scope.ranges[i] = $scope.ranges[i - 1];
+        }
+      } else {
+        for ( var i = start_pos; i < end_pos; i++ ) {
+          $scope.ranges[i] = $scope.ranges[i + 1];
+        }
+      }
+      $scope.ranges[end_pos] = draggedAnnotation;
+      console.log('Ranges =======>', $scope.ranges);
+    }
+  });
+
+})
+
+// This directive allows two-way data binding in contenteditable div
+.directive("contenteditable", function() {
+  return {
+    restrict: "A",
+    require: "ngModel",
+    link: function(scope, element, attrs, ngModel) {
+
+      function read() {
+        ngModel.$setViewValue(element.html());
+      }
+
+      ngModel.$render = function() {
+        element.html(ngModel.$viewValue || "");
+      };
+
+      element.bind("blur keyup change", function() {
+        scope.$apply(read);
+      });
+    }
+  };
 });


### PR DESCRIPTION
Since we do ng-repeat which uses data in $scope.ranges to render annotations, $scope.ranges need to be immediately updated whenever annotation changes. Changes include the order of annotations and the content of any annotation box:

When the order of annotations changes, the order of $scope.ranges changes accordingly (see lines 163-194 in _snippet.js_).

I augmented the object 'range' with property 'text' (see line 93 in _snippet.js_) and implemented two-way data binding using ng-model (see line 35 in _snippet.html_). In this case whenever the content of annotation box changes, its corresponding 'text' value is changed.
