### PR TITLE
Make font size of editor and annotations customizable

### DIFF
--- a/public/app/edit.html
+++ b/public/app/edit.html
@@ -26,7 +26,7 @@
       <div id="editor" ng-model="code"></div><!-- remove space between inline-blocks
    --><div id="annotations">
         <div ng-repeat="annotation in ranges track by $index" id="annotation-{{ annotation.id }}">
-          <div class="note highlighted-{{ annotation.color }}" spellcheck="false" ng-model="annotation.text" contenteditable="true">{{ annotation.text }}</div>
+          <div class="note highlighted-{{ annotation.color }}" spellcheck="false" ng-model="annotation.text" contenteditable="true" style="font-size:{{annotationSize}}px">{{ annotation.text }}</div>
           <button type="button" class="trash" ng-click="removeAnnotation()">
             <i class="fa fa-trash-o" aria-hidden="true"></i>
           </button>

--- a/public/app/edit.html
+++ b/public/app/edit.html
@@ -25,7 +25,7 @@
     <div class="editor-wrap">
       <div id="editor" ng-model="code"></div><!-- remove space between inline-blocks
    --><div id="annotations">
-        <div ng-repeat="annotation in ranges" id="annotation-{{ annotation.id }}">
+        <div ng-repeat="annotation in ranges track by $index" id="annotation-{{ annotation.id }}">
           <div class="note highlighted-{{ annotation.color }}" spellcheck="false" ng-model="annotation.text" contenteditable="true">{{ annotation.text }}</div>
           <button type="button" class="trash" ng-click="removeAnnotation()">
             <i class="fa fa-trash-o" aria-hidden="true"></i>

--- a/public/app/edit.html
+++ b/public/app/edit.html
@@ -34,9 +34,9 @@
       </div>
     </div>
     <p >Tags:</p>
-    <input type="text" class="tags" ng-model="tags[0]" placeholder="Enter a tag" /><br/>
-    <input type="text" class="tags" ng-model="tags[1]" placeholder="Enter a tag" /><br/>
-    <input type="text" class="tags" ng-model="tags[2]" placeholder="Enter a tag" /><br/>
+    <input type="text" class="tags" ng-model="tags1" placeholder="Enter a tag" /><br/>
+    <input type="text" class="tags" ng-model="tags2" placeholder="Enter a tag" /><br/>
+    <input type="text" class="tags" ng-model="tags3" placeholder="Enter a tag" /><br/>
     <div class="btn-wrap">
       <button class="btn" type="submit">Save snippet</button>
     </div>

--- a/public/app/edit.html
+++ b/public/app/edit.html
@@ -42,16 +42,3 @@
     </div>
   </form>
 </div>
-
-<script>
-  $(function() {
-
-    $(document).on('click', '.note', function(e){
-      if (! $(this).is(":focus") ) {
-        this.focus();
-      }
-    });
-
-    $( "#annotations" ).sortable();
-  });
-</script>

--- a/public/app/edit.js
+++ b/public/app/edit.js
@@ -89,6 +89,7 @@ angular.module('app.edit', [])
     range.id = $scope.rangeId;
     range.color = $scope.colorCount;
     range.marker = marker;
+    range.text = '';
     $scope.ranges.push(range);
 
     // TODO: focus cursor to new annotation
@@ -96,16 +97,15 @@ angular.module('app.edit', [])
   };
 
   $scope.snippetsEdit = function() {
-    var ranges = [];
-
-    $scope.ranges.forEach(function(range) {
-      // Using JSON.parse(JSON.stringify()) to break the reference.
-      // Just performing a range.text assignment was breaking the innerText.
-      var tempRange;
-      tempRange = JSON.parse(JSON.stringify(range));
-      tempRange.text = document.getElementById('annotation-' + range.id).childNodes[1].innerText;
-      ranges.push(tempRange);
-    });
+    // var ranges = [];
+    // $scope.ranges.forEach(function(range) {
+    //   // Using JSON.parse(JSON.stringify()) to break the reference.
+    //   // Just performing a range.text assignment was breaking the innerText.
+    //   var tempRange;
+    //   tempRange = JSON.parse(JSON.stringify(range));
+    //   tempRange.text = document.getElementById('annotation-' + range.id).childNodes[1].innerText;
+    //   ranges.push(tempRange);
+    // });
 
     var tags = [];
     if ($scope.tags[0]) { tags.push($scope.tags[0]); }
@@ -116,10 +116,11 @@ angular.module('app.edit', [])
       title: $scope.title,
       isPrivate: $scope.isPrivate,
       code: editor.getValue(),
-      highlights: ranges,
+      highlights: $scope.ranges,
       tags: tags
     };
 
+    console.log('Snippet that we save into database =======>', snippet);
 
     $http({
       method: 'PATCH',
@@ -205,7 +206,7 @@ angular.module('app.edit', [])
     target.setAttribute('data-x', x);
     target.setAttribute('data-y', y);
   });
-  
+
   //jQuery function which handles user actions
   $(document).on('click', '.note', function(e){
       if (! $(this).is(":focus") ) {

--- a/public/app/edit.js
+++ b/public/app/edit.js
@@ -120,6 +120,7 @@ angular.module('app.edit', [])
       tags: tags
     };
 
+
     $http({
       method: 'PATCH',
       url: '/snippets/' + $routeParams.id,
@@ -181,6 +182,30 @@ angular.module('app.edit', [])
     });
   }();
 
+  // Make editor of adjustable height
+  interact('.editor-wrap')
+  .resizable({
+    preserveAspectRatio: true,
+    edges: { left: false, right: false, bottom: true, top: false }
+  })
+  .on('resizemove', function (event) {
+    var target = event.target,
+        x = (parseFloat(target.getAttribute('data-x')) || 0),
+        y = (parseFloat(target.getAttribute('data-y')) || 0);
+
+    // update the element's style
+    target.style.height = event.rect.height + 'px';
+
+    target.style.webkitTransform = target.style.transform =
+        'translate(' + 0 + 'px,' + y + 'px)';
+
+    $( "#annotations, #editor" ).height(event.rect.height)
+    editor.resize();
+
+    target.setAttribute('data-x', x);
+    target.setAttribute('data-y', y);
+  });
+  
   //jQuery function which handles user actions
   $(document).on('click', '.note', function(e){
       if (! $(this).is(":focus") ) {
@@ -193,7 +218,7 @@ angular.module('app.edit', [])
   $( "#annotations" ).sortable({
     start: function(event, div) {
       start_pos = div.item.index();
-      console.log('starting position ===========>', start_pos);
+      // console.log('starting position ===========>', start_pos);
     },
 
     change: function(event, div) {
@@ -204,7 +229,7 @@ angular.module('app.edit', [])
     },
 
     stop: function(event) {
-      console.log('ending position =============>', end_pos);
+      // console.log('ending position =============>', end_pos);
       // reorder $scope.ranges based on the order of annotations
       var draggedAnnotation = $scope.ranges[start_pos];
       if ( start_pos > end_pos ) {
@@ -217,7 +242,7 @@ angular.module('app.edit', [])
         }
       }
       $scope.ranges[end_pos] = draggedAnnotation;
-      console.log('Ranges =======>', $scope.ranges);
+      // console.log('Ranges =======>', $scope.ranges);
     }
   });
 })

--- a/public/app/edit.js
+++ b/public/app/edit.js
@@ -17,15 +17,18 @@ angular.module('app.edit', [])
   editor.$blockScrolling = Infinity;
 
   // Adjust font size in editor when +/- button is clicked
-  $scope.fontSize = 12;
+  $scope.fontSize = 16;
+  $scope.annotationSize = 12;
   editor.setFontSize($scope.fontSize);
 
   $scope.enlargeText = function () {
     $scope.fontSize += 2;
+    $scope.annotationSize++;
     editor.setFontSize($scope.fontSize);
   };
   $scope.reduceText = function () {
     $scope.fontSize -= 2;
+    $scope.annotationSize--;
     editor.setFontSize($scope.fontSize);
   };
 
@@ -115,6 +118,8 @@ angular.module('app.edit', [])
     var snippet = {
       title: $scope.title,
       isPrivate: $scope.isPrivate,
+      fontSize: $scope.fontSize,
+      annotationSize: $scope.annotationSize,
       code: editor.getValue(),
       highlights: $scope.ranges,
       tags: tags

--- a/public/app/edit.js
+++ b/public/app/edit.js
@@ -108,9 +108,9 @@ angular.module('app.edit', [])
     // });
 
     var tags = [];
-    if ($scope.tags[0]) { tags.push($scope.tags[0]); }
-    if ($scope.tags[1]) { tags.push($scope.tags[1]); }
-    if ($scope.tags[2]) { tags.push($scope.tags[2]); }
+    if ($scope.tags1) { tags.push($scope.tags1); }
+    if ($scope.tags2) { tags.push($scope.tags2); }
+    if ($scope.tags3) { tags.push($scope.tags3); }
 
     var snippet = {
       title: $scope.title,

--- a/public/app/edit.js
+++ b/public/app/edit.js
@@ -110,7 +110,7 @@ angular.module('app.edit', [])
     var tags = [];
     if ($scope.tags[0]) { tags.push($scope.tags[0]); }
     if ($scope.tags[1]) { tags.push($scope.tags[1]); }
-    if ($scope.tags[1]) { tags.push($scope.tags[2]); }
+    if ($scope.tags[2]) { tags.push($scope.tags[2]); }
 
     var snippet = {
       title: $scope.title,

--- a/public/app/edit.js
+++ b/public/app/edit.js
@@ -145,6 +145,7 @@ angular.module('app.edit', [])
     Snippets.exportImage($scope.title);
   };
 
+
   $scope.init = function() {
     Snippets.retrieveSnippet($routeParams.id)
     .then(function(snippet) {
@@ -179,6 +180,46 @@ angular.module('app.edit', [])
       }
     });
   }();
+
+  //jQuery function which handles user actions
+  $(document).on('click', '.note', function(e){
+      if (! $(this).is(":focus") ) {
+        this.focus();
+      }
+  });
+
+  var start_pos;
+  var end_pos;
+  $( "#annotations" ).sortable({
+    start: function(event, div) {
+      start_pos = div.item.index();
+      console.log('starting position ===========>', start_pos);
+    },
+
+    change: function(event, div) {
+      end_pos = div.placeholder.index();
+      if ( start_pos < end_pos ) {
+        end_pos -= 1;
+      }
+    },
+
+    stop: function(event) {
+      console.log('ending position =============>', end_pos);
+      // reorder $scope.ranges based on the order of annotations
+      var draggedAnnotation = $scope.ranges[start_pos];
+      if ( start_pos > end_pos ) {
+        for ( var i = start_pos; i > end_pos; i-- ) {
+          $scope.ranges[i] = $scope.ranges[i - 1];
+        }
+      } else {
+        for ( var i = start_pos; i < end_pos; i++ ) {
+          $scope.ranges[i] = $scope.ranges[i + 1];
+        }
+      }
+      $scope.ranges[end_pos] = draggedAnnotation;
+      console.log('Ranges =======>', $scope.ranges);
+    }
+  });
 })
 
 // This directive allows two-way data binding in contenteditable div

--- a/public/app/snippet.html
+++ b/public/app/snippet.html
@@ -34,7 +34,7 @@
       </div><!-- remove space between inline-blocks
    --><div id="annotations">
         <div ng-repeat="annotation in ranges track by $index" id="annotation-{{ annotation.id }}">
-          <div class="note highlighted-{{ annotation.color }}" spellcheck="false" contenteditable="true" ng-model="annotation.text"> {{annotation.text}}
+          <div class="note highlighted-{{ annotation.color }}" spellcheck="false" contenteditable="true" ng-model="annotation.text" style="font-size:{{annotationSize}}px"> {{annotation.text}}
           </div>
           <button type="button" class="trash" ng-click="removeAnnotation()">
             <i class="fa fa-trash-o" aria-hidden="true"></i>

--- a/public/app/snippet.js
+++ b/public/app/snippet.js
@@ -22,14 +22,17 @@ angular.module('app.snippet', [])
 
   // Adjust font size in editor when +/- button is clicked
   $scope.fontSize = 16;
+  $scope.annotationSize = 12;
   editor.setFontSize($scope.fontSize);
 
   $scope.enlargeText = function () {
     $scope.fontSize += 2;
+    $scope.annotationSize++;
     editor.setFontSize($scope.fontSize);
   };
   $scope.reduceText = function () {
     $scope.fontSize -= 2;
+    $scope.annotationSize--;
     editor.setFontSize($scope.fontSize);
   };
 
@@ -120,6 +123,8 @@ angular.module('app.snippet', [])
     var snippet = {
       title: $scope.title,
       isPrivate: $scope.isPrivate,
+      fontSize: $scope.fontSize,
+      annotationSize: $scope.annotationSize,
       code: editor.getValue(),
       highlights: $scope.ranges,
       tags: tags

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -262,7 +262,6 @@ label {
    display:inline-block;
    height: auto;
    width: 80%;
-   font-size: 12px;
    padding: 2%;
    margin: 2% 0 2% 2%;
    vertical-align: top;


### PR DESCRIPTION
Since we need to record the font size I augmented _snippet_ object with two properties - fontSize and annotationSize.

If _snippet_ changes, schema and database need to be changed as well. Yet to ensure everyone can keep track of this pull request I leave the database unchanged. Once this pull request has been merged (or modified before being merged if necessary) I would head over to database.
