### PR TITLE
Stop ace editor from initially highlighting all code on load

### DIFF
--- a/public/app/edit.js
+++ b/public/app/edit.js
@@ -158,7 +158,7 @@ angular.module('app.edit', [])
         $scope.tags = snippet.data.tags;
 
         // add code to editor
-        editor.setValue(snippet.data.code);
+        editor.setValue(snippet.data.code, -1);
 
         snippet.data.highlights.forEach(function(highlight) {
           // set markers for highlighted code

--- a/public/app/main.js
+++ b/public/app/main.js
@@ -40,7 +40,7 @@ angular.module('app.main', [])
       editors[snippet._id].setReadOnly(true);
 
       // add code to editor
-      editors[snippet._id].setValue(snippet.code);
+      editors[snippet._id].setValue(snippet.code, -1);
 
       // setup highlights/annotations array
       $scope.highlights[snippet._id] = [];

--- a/public/app/snippets.js
+++ b/public/app/snippets.js
@@ -82,7 +82,7 @@ angular.module('app.snippets', [])
       editors[snippet._id].setReadOnly(true);
 
       // add code to editor
-      editors[snippet._id].setValue(snippet.code);
+      editors[snippet._id].setValue(snippet.code, -1);
 
       // setup highlights/annotations array
       $scope.highlights[snippet._id] = [];

--- a/public/app/view.js
+++ b/public/app/view.js
@@ -42,7 +42,7 @@ angular.module('app.view', [])
         $scope.editAccess = (snippet.data.userName === Auth.getUserName()) ? true : false;
 
         // add code to editor
-        editor.setValue(snippet.data.code);
+        editor.setValue(snippet.data.code, -1);
         editor.setFontSize(16);
 
         snippet.data.highlights.forEach(function(highlight) {


### PR DESCRIPTION
This fixes #118 
